### PR TITLE
Update setup.py: Add numpy to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ include_dirs = [np.get_include()]
 
 setup(name="pystruct",
       version="0.2.5",
-      install_requires=["ad3"],
+      install_requires=["ad3", "numpy"],
       packages=['pystruct', 'pystruct.learners', 'pystruct.inference',
                 'pystruct.models', 'pystruct.utils', 'pystruct.datasets',
                 'pystruct.tests', 'pystruct.tests.test_learners',


### PR DESCRIPTION
setup.py imports numpy. This is a problem when the computer running `pip install pystruct` doesn't already have numpy installed. Not sure if adding numpy to install_requires really helps, but it also doesn't hurt. The real fix may involve removing `import numpy as np` from setup.py altogether.